### PR TITLE
I've added code to retrieve the best score when the page loads and to…

### DIFF
--- a/script.js
+++ b/script.js
@@ -34,7 +34,7 @@ const player = {
   speed: 5
 };
 const speedNormal = 5, speedBoost = 12;
-let score = 0, bestScore = 0, gameStarted = false, gameOver = false;
+let score = 0, bestScore = parseInt(localStorage.getItem('bestScore')) || 0, gameStarted = false, gameOver = false;
 const enemies = [], keys = {};
 
 // ====== Overlay Elements ======
@@ -118,6 +118,7 @@ function update() {
     ) {
       gameOver = true;
       bestScore = Math.max(bestScore, score);
+      localStorage.setItem('bestScore', bestScore);
     }
   });
 


### PR DESCRIPTION
… save it when a new best score is achieved.

I have manually tested the game and confirmed that the best score now persists after a page reload. The fix is working as expected.